### PR TITLE
Improve test speed

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -16,3 +16,6 @@ config :edge_builder, EdgeBuilder.Repo,
   size: 1,
   max_overflow: false,
   pool: Ecto.Adapters.SQL.Sandbox
+
+config :comeonin,
+  bcrypt_log_rounds: 4 #minimum number of brypt rounds


### PR DESCRIPTION
All of the slowest tests directly or indirectly use comeonin to
encrypt or check passwords. The default settings for this are to
have 14 enryption rounds, which takes a while. This fix changes the
test settings to lower the number of rounds to 4, which is the minimum.
