### PR TITLE
Small change to CSS

### DIFF
--- a/priv/static/css/site.css
+++ b/priv/static/css/site.css
@@ -157,7 +157,7 @@ h4 {
 }
 
 .creation-list-group-item {
-  height: 120;
+  height: 120px;
   padding-top: 15px;
   padding-bottom: 5px;
 }


### PR DESCRIPTION
`.creation-list-group-item` missing `px`  after value. This makes vehicles listed on homepage same size as characters. Closes #47
