### PR TITLE
Add Handling to Vehicle UI.

### DIFF
--- a/test/controllers/vehicle_controller_test.exs
+++ b/test/controllers/vehicle_controller_test.exs
@@ -45,6 +45,7 @@ defmodule EdgeBuilder.Controllers.VehicleControllerTest do
           "defense_starboard_current" => "0",
           "encumbrance" => "100",
           "faction" => "Thunderbirds",
+          "handling" => "2",
           "hard_points" => "4",
           "hull_current" => "4",
           "hull_threshold" => "15",
@@ -91,6 +92,7 @@ defmodule EdgeBuilder.Controllers.VehicleControllerTest do
       assert vehicle.defense_starboard_current == 0
       assert vehicle.encumbrance == "100"
       assert vehicle.faction == "Thunderbirds"
+      assert vehicle.handling == 2
       assert vehicle.hard_points == 4
       assert vehicle.hull_current == 4
       assert vehicle.hull_threshold == 15

--- a/web/templates/vehicle/_form.html.eex
+++ b/web/templates/vehicle/_form.html.eex
@@ -43,16 +43,6 @@
       <div class='col-sm-3 form-group'>
         <div class="panel panel-default">
           <div class="panel-body">
-            <input type="number" min=0 max=10 step=1 class="form-control" name="vehicle[armor]" value="<%= get_field(@vehicle, :armor) %>" />
-          </div>
-          <div class="panel-footer text-center">
-            <label for="vehicle[armor]">Armor</label>
-          </div>
-        </div>
-      </div>
-      <div class='col-sm-3 form-group'>
-        <div class="panel panel-default">
-          <div class="panel-body">
             <input type="number" min=0 max=10 step=1 class="form-control" name="vehicle[speed]" value="<%= get_field(@vehicle, :speed) %>" />
           </div>
           <div class="panel-footer text-center">
@@ -67,6 +57,16 @@
           </div>
           <div class="panel-footer text-center">
             <label for="vehicle[current_speed]">Cur. Speed</label>
+          </div>
+        </div>
+      </div>
+      <div class='col-sm-3 form-group'>
+        <div class="panel panel-default">
+          <div class="panel-body">
+            <input type="number" min=0 max=10 step=1 class="form-control" name="vehicle[handling]" value="<%= get_field(@vehicle, :handling) %>" />
+          </div>
+          <div class="panel-footer text-center">
+            <label for="vehicle[handling]">Handling</label>
           </div>
         </div>
       </div>
@@ -86,6 +86,16 @@
 <div class='row'>
   <div class='col-lg-2'>
     <div class='row'>
+      <div class='col-lg-12 col-xs-6'>
+        <div class="panel panel-default">
+          <div class="panel-body">
+            <input type="number" min=0 max=10 step=1 class="form-control" name="vehicle[armor]" value="<%= get_field(@vehicle, :armor) %>" />
+          </div>
+          <div class="panel-footer text-center">
+            <label for="vehicle[armor]">Armor</label>
+          </div>
+        </div>
+      </div>
       <div class='col-lg-12 col-xs-6'>
         <div class="panel panel-default">
           <div class="panel-body">

--- a/web/templates/vehicle/show.html.eex
+++ b/web/templates/vehicle/show.html.eex
@@ -41,16 +41,6 @@
       <div class='col-sm-3 col-xs-6'>
         <div class="panel panel-default">
           <div class="panel-body panel-value">
-            <%= get_field(@vehicle, :armor) %>
-          </div>
-          <div class="panel-footer text-center">
-            Armor
-          </div>
-        </div>
-      </div>
-      <div class='col-sm-3 col-xs-6'>
-        <div class="panel panel-default">
-          <div class="panel-body panel-value">
             <%= get_field(@vehicle, :speed) %>
           </div>
           <div class="panel-footer text-center">
@@ -68,6 +58,16 @@
           </div>
         </div>
       </div>
+      <div class='col-sm-3 col-xs-6'>
+        <div class="panel panel-default">
+          <div class="panel-body panel-value">
+            <%= get_field(@vehicle, :handling) %>
+          </div>
+          <div class="panel-footer text-center">
+            Handling
+          </div>
+        </div>
+      </div>
     </div>
   </div>
   <%= unless is_nil(get_field(@vehicle, :portrait_url)) do %>
@@ -82,6 +82,16 @@
 <div class='row'>
   <div class='col-lg-2'>
     <div class='row'>
+      <div class='col-lg-12 col-xs-6'>
+        <div class="panel panel-default">
+          <div class="panel-body panel-value">
+            <%= get_field(@vehicle, :armor) %>
+          </div>
+          <div class="panel-footer text-center">
+            Armor
+          </div>
+        </div>
+      </div>
       <div class='col-lg-12 col-xs-6'>
         <div class="panel panel-default">
           <div class='panel-body'>


### PR DESCRIPTION
Handling was previously added to the UI but not being displayed on the vehicle page. I've reorganized the Vehicle _form/show pages to be closer to the [official vehicle sheet](https://images-cdn.fantasyflightgames.com/filer_public/16/fc/16fcc64a-2a88-467f-a701-55c64f617567/edge-of-the-empire-vehicle-sheet.pdf).

A screenshot of what this looks like now:
<img width="1153" alt="vehicle_handling" src="https://cloud.githubusercontent.com/assets/71199/15976086/5e9e9bb2-2f16-11e6-916b-bc5f693d2391.png">
