### PR TITLE
404 when user does not exist

### DIFF
--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -55,7 +55,7 @@ defmodule EdgeBuilder.Models.User do
 
   def by_username(nil), do: nil
   def by_username(username) do
-    Repo.one(
+    Repo.one!(
       from u in __MODULE__,
         where: fragment("upper(username)") == ^String.upcase(username)
     )


### PR DESCRIPTION
Instead of allowing a 500, 404 when a user does not exist.

Closes #90.