### PR TITLE
Add user error when login form is empty

### DIFF
--- a/test/controllers/signup_controller_test.exs
+++ b/test/controllers/signup_controller_test.exs
@@ -106,6 +106,28 @@ defmodule EdgeBuilder.Controllers.SignupControllerTest do
 
       assert FlokiExt.element(conn, ".alert-danger") |> FlokiExt.text == "No matching username and password could be found"
     end
+
+    it "displays an error message when the username field is empty" do
+      conn = build_conn() |> post("/login", %{
+        "login" => %{
+          "username" => nil,
+          "password" => "diagonally"
+        }
+      })
+
+      assert FlokiExt.element(conn, ".alert-danger") |> FlokiExt.text == "Username or password cannot be empty"
+    end
+
+    it "displays an error message when the password field is empty" do
+      conn = build_conn() |> post("/login", %{
+        "login" => %{
+          "username" => "harry potter",
+          "password" => nil
+        }
+      })
+
+      assert FlokiExt.element(conn, ".alert-danger") |> FlokiExt.text == "Username or password cannot be empty"
+    end
   end
 
   describe "logout" do

--- a/web/controllers/signup_controller.ex
+++ b/web/controllers/signup_controller.ex
@@ -7,6 +7,11 @@ defmodule EdgeBuilder.SignupController do
     render conn, "welcome.html"
   end
 
+  def login(conn, %{"login" => %{"username" => username, "password" => password}})
+    when is_nil(username) or is_nil(password) do
+      conn 
+      |> render("welcome.html", login_empty: true)
+  end
   def login(conn, %{"login" => %{"username" => username, "password" => password}}) do
     case User.authenticate(username, password) do
       {:ok, user} -> 

--- a/web/templates/signup/welcome.html.eex
+++ b/web/templates/signup/welcome.html.eex
@@ -4,6 +4,10 @@
   <div class="alert alert-danger"><p>No matching username and password could be found</p></div>
 <% end %>
 
+<%= unless is_nil(assigns[:login_empty]) do %>
+  <div class="alert alert-danger"><p>Username or password cannot be empty</p></div>
+<% end %>
+
 <style>
   .row {
     height: 450px;


### PR DESCRIPTION
Add a check and error message for the login form for when the username or password are empty.

Closes #91.