### PR TITLE
Fix welcome page on smaller widths

### DIFF
--- a/web/templates/signup/welcome.html.eex
+++ b/web/templates/signup/welcome.html.eex
@@ -9,9 +9,6 @@
 <% end %>
 
 <style>
-  .row {
-    height: 450px;
-  }
   .col-md-offset-2 {
     margin-top: 70px;
   }
@@ -20,13 +17,8 @@
     height: 100%;
   }
 
-  .vertical-line {
-    width: 1px;
-    border-left: 1px solid #000;
-    margin-left: auto;
-    margin-right: auto;
-    vertical-align:  baseline;
-    height: 100%;
+  .col-md-5 {
+    margin-bottom: 70px;
   }
 </style>
 
@@ -49,11 +41,9 @@
     </div>
   </div>
 
-  <div class="col-md-1">
-    <div class="vertical-line"></div>
-  </div>
+  <div class="col-md-1"></div>
 
-  <div class="col-md-6">
+  <div class="col-md-5">
     <h3>Create a New Account</h3>
     <%= form_tag(signup_path(@conn, :signup), role: "form", method: "POST", class: "form") %>
       <div class="form-group">


### PR DESCRIPTION
CSS is far from my strong point. Are you okay with the just removing the vertical line?

<img width="1506" alt="Screen Shot 2019-12-15 at 1 38 54 PM" src="https://user-images.githubusercontent.com/3457341/70868680-45f0d300-1f40-11ea-882a-28c9512f3774.png">

<img width="911" alt="Screen Shot 2019-12-15 at 1 35 15 PM" src="https://user-images.githubusercontent.com/3457341/70868681-49845a00-1f40-11ea-80ab-b903c7310e94.png">

Closes #109 