### PR TITLE
Hide the overflow for longer resource names

### DIFF
--- a/priv/static/css/site.css
+++ b/priv/static/css/site.css
@@ -165,10 +165,18 @@ h4 {
 .creation-list-group-item h3 {
   margin-bottom: 10px;
   color: #337ab7 !important;
+  width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .creation-list-group-item p {
   font-size: 110%;
+  width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .creation-list-group-item .creation-thumbnail {


### PR DESCRIPTION
This adds some overflow styling for characters and vehicles with names too long that they break the list group styling. Of course, open to suggestions, but I think this looks pretty good.

<img width="1070" alt="Screen Shot 2019-12-17 at 8 13 29 PM" src="https://user-images.githubusercontent.com/3457341/71052825-cf073600-2109-11ea-932f-4cb6f885fc49.png">

Closes #119 