### PR TITLE
Add column for character talent rank

### DIFF
--- a/priv/repo/migrations/20191218032904_add_character_talent_rank.exs
+++ b/priv/repo/migrations/20191218032904_add_character_talent_rank.exs
@@ -1,0 +1,9 @@
+defmodule EdgeBuilder.Repo.Migrations.AddCharacterTalentRank do
+  use Ecto.Migration
+
+  def change do
+    alter table(:talents) do
+      add :rank, :integer, default: 1
+    end 
+  end
+end

--- a/priv/static/js/character.js
+++ b/priv/static/js/character.js
@@ -57,6 +57,7 @@ var CharacterForm = (function() {
     talentRow.find("[for]").attr("for", function(i, currentFor) { return currentFor.replace("talents["+previousIndex+"]", "talents["+index+"]") });
     talentRow.find("[name='talents["+index+"][id]']").remove();
     talentRow.find("[name='talents["+index+"][display_order]']").val(index);
+    talentRow.find("[name='talents["+index+"][rank]']").val("1");
     talentRow.find("[data-remove-talent]").attr("data-remove-talent", index);
 
     enableDisableRemoveTalentButtons();

--- a/test/controllers/character_controller_test.exs
+++ b/test/controllers/character_controller_test.exs
@@ -84,8 +84,8 @@ defmodule EdgeBuilder.Controllers.CharacterControllerTest do
         },
         "skills" => skills_with_user_edit,
         "talents" => %{
-          "0" => %{"book_and_page" => "EotE p25", "description" => "Draw as incidental", "name" => "Quick Draw"},
-          "1" => %{"book_and_page" => "DC p200", "description" => "Upgrade all checks by one", "name" => "Adversary 1"}
+          "0" => %{"rank" => 1, "book_and_page" => "EotE p25", "description" => "Draw as incidental", "name" => "Quick Draw"},
+          "1" => %{"rank" => 2, "book_and_page" => "DC p200", "description" => "Upgrade all checks by one", "name" => "Adversary 1"}
         },
       })
 
@@ -131,10 +131,12 @@ defmodule EdgeBuilder.Controllers.CharacterControllerTest do
 
       [first_talent, second_talent] = Talent.for_character(character.id)
 
+      assert first_talent.rank == 1
       assert first_talent.book_and_page == "EotE p25"
       assert first_talent.description == "Draw as incidental"
       assert first_talent.name == "Quick Draw"
 
+      assert second_talent.rank == 2
       assert second_talent.book_and_page == "DC p200"
       assert second_talent.description == "Upgrade all checks by one"
       assert second_talent.name == "Adversary 1"
@@ -250,9 +252,9 @@ defmodule EdgeBuilder.Controllers.CharacterControllerTest do
           "2" => %{"id" => "", "critical" => "5", "damage" => "+1", "range" => "Engaged", "base_skill_id" => BaseSkill.by_name("Brawl").id, "specials" => "", "weapon_name" => "Claws", "display_order" => "2"}
         },
         "talents" => %{
-          "1" => %{"book_and_page" => "EotE p25", "description" => "Draw as incidental", "name" => "Quick Draw", "display_order" => "1"},
-          "10" => %{"book_and_page" => "DC p200", "description" => "Upgrade all checks by one", "name" => "Adversary 1", "display_order" => "10"},
-          "2" => %{"book_and_page" => "NR 100", "description" => "Launch a fire bomb attack", "name" => "Fire Bomb", "display_order" => "2"}
+          "1" => %{"rank" => 1, "book_and_page" => "EotE p25", "description" => "Draw as incidental", "name" => "Quick Draw", "display_order" => "1"},
+          "10" => %{"rank" => 1, "book_and_page" => "DC p200", "description" => "Upgrade all checks by one", "name" => "Adversary 1", "display_order" => "10"},
+          "2" => %{"rank" => 1, "book_and_page" => "NR 100", "description" => "Launch a fire bomb attack", "name" => "Fire Bomb", "display_order" => "2"}
         },
       })
 
@@ -468,6 +470,7 @@ defmodule EdgeBuilder.Controllers.CharacterControllerTest do
       character = CharacterFactory.create_character
 
       talent = %Talent{
+        rank: 1,
         name: "Quick Draw",
         book_and_page: "EotE Core p145",
         description: "Draws a gun quickly",
@@ -475,11 +478,12 @@ defmodule EdgeBuilder.Controllers.CharacterControllerTest do
       } |> Repo.insert!
 
       build_conn() |> authenticate_as(UserFactory.default_user) |> put("/c/#{character.permalink}", %{"character" => %{}, "talents" => %{
-        "0" => %{"book_and_page" => "DC p43", "description" => "Do stuff", "id" => talent.id, "name" => "Awesome Guy"}
+        "0" => %{"rank" => 2, "book_and_page" => "DC p43", "description" => "Do stuff", "id" => talent.id, "name" => "Awesome Guy"}
       }})
 
       [talent] = Talent.for_character(character.id)
 
+      assert talent.rank == 2
       assert talent.name == "Awesome Guy"
       assert talent.description == "Do stuff"
       assert talent.book_and_page == "DC p43"
@@ -489,11 +493,12 @@ defmodule EdgeBuilder.Controllers.CharacterControllerTest do
       character = CharacterFactory.create_character
 
       build_conn() |> authenticate_as(UserFactory.default_user) |> put("/c/#{character.permalink}", %{"character" => %{}, "talents" => %{
-        "0" => %{"book_and_page" => "DC p43", "description" => "Do stuff", "name" => "Awesome Guy"}
+        "0" => %{"rank" => 1, "book_and_page" => "DC p43", "description" => "Do stuff", "name" => "Awesome Guy"}
       }})
 
       [talent] = Talent.for_character(character.id)
 
+      assert talent.rank == 1
       assert talent.name == "Awesome Guy"
       assert talent.description == "Do stuff"
       assert talent.book_and_page == "DC p43"
@@ -510,8 +515,8 @@ defmodule EdgeBuilder.Controllers.CharacterControllerTest do
       } |> Repo.insert!
 
       build_conn() |> authenticate_as(UserFactory.default_user) |> put("/c/#{character.permalink}", %{"character" => %{}, "talents" => %{
-        "0" => %{"book_and_page" => "", "description" => "", "name" => ""},
-        "1" => %{"book_and_page" => "", "description" => "", "name" => "", "id" => talent.id}
+        "0" => %{"rank" => 1, "book_and_page" => "", "description" => "", "name" => ""},
+        "1" => %{"rank" => 1, "book_and_page" => "", "description" => "", "name" => "", "id" => talent.id}
       }})
 
       assert [] == Talent.for_character(character.id)
@@ -521,6 +526,7 @@ defmodule EdgeBuilder.Controllers.CharacterControllerTest do
       character = CharacterFactory.create_character
 
       %Talent{
+        rank: 2,
         name: "Quick Draw",
         book_and_page: "EotE Core p145",
         description: "Draws a gun quickly",

--- a/test/models/talent_test.exs
+++ b/test/models/talent_test.exs
@@ -14,16 +14,37 @@ defmodule EdgeBuilder.Models.TalentTest do
       } |> Repo.insert!
 
       greedos_talent = %Talent{
+        rank: 2,
         name: "Witty Repartee",
         character_id: character.id
       } |> Repo.insert!
 
       _different_talent = %Talent{
+        rank: 1,
         name: "Quick Draw",
         character_id: character.id + 1
       } |> Repo.insert!
 
       assert Talent.for_character(character.id) == [greedos_talent]
+    end
+  end
+
+  describe "model defaults" do
+    it "defaults to rank 1 if no rank is specified" do
+      character = %Character{
+        name: "Greedo",
+        species: "Rodian",
+        career: "Bounty Hunter"
+      } |> Repo.insert!
+
+      _greedos_talent = %Talent{
+        name: "Witty Repartee",
+        character_id: character.id
+      } |> Repo.insert!
+
+      [talent] = Talent.for_character(character.id)
+
+      assert talent.rank == 1
     end
   end
 end

--- a/web/models/talent.ex
+++ b/web/models/talent.ex
@@ -4,6 +4,7 @@ defmodule EdgeBuilder.Models.Talent do
   alias EdgeBuilder.Models.Character
 
   schema "talents" do
+    field :rank, :integer, default: 1
     field :name, :string
     field :book_and_page, :string
     field :description, :string
@@ -13,13 +14,13 @@ defmodule EdgeBuilder.Models.Talent do
 
   def changeset(talent, params \\ %{}) do
     talent
-    |> cast(params, ~w(character_id name book_and_page description display_order)a)
+    |> cast(params, ~w(character_id rank name book_and_page description display_order)a)
   end
 
   def is_default_changeset?(changeset) do
     default = struct(__MODULE__)
 
-    Enum.all?([:name, :book_and_page, :description], fn field ->
+    Enum.all?([:name, :rank, :book_and_page, :description], fn field ->
       value = Ecto.Changeset.get_field(changeset, field)
       is_nil(value) || value == Map.fetch!(default, field)
     end)

--- a/web/templates/character/_form_talents.html.eex
+++ b/web/templates/character/_form_talents.html.eex
@@ -2,25 +2,25 @@
 <div class="row">
   <table id="talentTable" class="table table-condensed">
     <tr>
-      <th class="col-md-1">Rank</th>
       <th class="col-md-3">Name</th>
+      <th class="col-md-1">Rank</th>
       <th class="col-md-2">Book &amp; Page</th>
       <th class="col-md-6" colspan=2>Description</th>
     </tr>
     <%= for {talent, i} <- Enum.with_index(@talents) do %>
       <tr class="talent-row" data-talent="<%= i %>">
         <td>
-          <div class="form-group-sm">
-            <label for="talents[<%= i %>][rank]" class="sr-only">Rank</label>
-            <input type="text" class="form-control" name="talents[<%= i %>][rank]" placeholder="Rank" value="<%= get_field(talent, :rank) %>" />
-          </div>
-        </td>
-        <td>
           <input type="hidden" name="talents[<%= i %>][id]" value="<%= get_field(talent, :id) %>" />
           <input type="hidden" name="talents[<%= i %>][display_order]" value="<%= get_field(talent, :display_order) %>" />
           <div class="form-group-sm">
             <label for="talents[<%= i %>][name]" class="sr-only">Name</label>
             <input type="text" class="form-control" name="talents[<%= i %>][name]" placeholder="Name" value="<%= get_field(talent, :name) %>" />
+          </div>
+        </td>
+        <td>
+          <div class="form-group-sm">
+            <label for="talents[<%= i %>][rank]" class="sr-only">Rank</label>
+            <input type="text" class="form-control" name="talents[<%= i %>][rank]" placeholder="Rank" value="<%= get_field(talent, :rank) %>" />
           </div>
         </td>
         <td>

--- a/web/templates/character/_form_talents.html.eex
+++ b/web/templates/character/_form_talents.html.eex
@@ -2,12 +2,19 @@
 <div class="row">
   <table id="talentTable" class="table table-condensed">
     <tr>
+      <th class="col-md-1">Rank</th>
       <th class="col-md-3">Name</th>
       <th class="col-md-2">Book &amp; Page</th>
-      <th class="col-md-7" colspan=2>Description</th>
+      <th class="col-md-6" colspan=2>Description</th>
     </tr>
     <%= for {talent, i} <- Enum.with_index(@talents) do %>
       <tr class="talent-row" data-talent="<%= i %>">
+        <td>
+          <div class="form-group-sm">
+            <label for="talents[<%= i %>][rank]" class="sr-only">Rank</label>
+            <input type="text" class="form-control" name="talents[<%= i %>][rank]" placeholder="Rank" value="<%= get_field(talent, :rank) %>" />
+          </div>
+        </td>
         <td>
           <input type="hidden" name="talents[<%= i %>][id]" value="<%= get_field(talent, :id) %>" />
           <input type="hidden" name="talents[<%= i %>][display_order]" value="<%= get_field(talent, :display_order) %>" />

--- a/web/templates/character/_show_talents.html.eex
+++ b/web/templates/character/_show_talents.html.eex
@@ -2,12 +2,16 @@
 <div class="row">
   <table class="table table-condensed">
     <tr>
+      <th class="col-md-1">Rank</th>
       <th class="col-md-3">Name</th>
       <th class="col-md-2">Book &amp; Page</th>
-      <th class="col-md-7">Description</th>
+      <th class="col-md-6">Description</th>
     </tr>
     <%= for talent <- @talents do %>
       <tr>
+        <td>
+          <%= get_field(talent, :rank) %>
+        </td>
         <td>
           <%= get_field(talent, :name) %>
         </td>

--- a/web/templates/character/_show_talents.html.eex
+++ b/web/templates/character/_show_talents.html.eex
@@ -2,18 +2,18 @@
 <div class="row">
   <table class="table table-condensed">
     <tr>
-      <th class="col-md-1">Rank</th>
       <th class="col-md-3">Name</th>
+      <th class="col-md-1">Rank</th>
       <th class="col-md-2">Book &amp; Page</th>
       <th class="col-md-6">Description</th>
     </tr>
     <%= for talent <- @talents do %>
       <tr>
         <td>
-          <%= get_field(talent, :rank) %>
+          <%= get_field(talent, :name) %>
         </td>
         <td>
-          <%= get_field(talent, :name) %>
+          <%= get_field(talent, :rank) %>
         </td>
         <td>
           <%= get_field(talent, :book_and_page) %>


### PR DESCRIPTION
Adds a column for character talent rank.

<img width="1260" alt="Screen Shot 2019-12-17 at 9 11 21 PM" src="https://user-images.githubusercontent.com/3457341/71055197-f7932e00-2111-11ea-84f7-bfffa22b60c8.png">

<img width="1253" alt="Screen Shot 2019-12-17 at 9 11 35 PM" src="https://user-images.githubusercontent.com/3457341/71055200-f95cf180-2111-11ea-8cbb-7d5201002499.png">

I suppose the one potential issue here is that you could now add a talent, only change the rank from the default 1, and it would get saved.

Closes #121