### PR TITLE
Release 2.0.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule EdgeBuilder.Mixfile do
 
   def project do
     [app: :edge_builder,
-     version: "0.0.2",
+     version: "2.0.0",
      elixir: "~> 1.8",
      elixirc_paths: elixirc_paths(Mix.env),
      compilers: [:phoenix] ++ Mix.compilers,


### PR DESCRIPTION
We'll call the deployment with the styling update version 2.0.0 and make GitHub releases from here. It's easier to see what was shipped when this way.