### PR TITLE
Add Sentry

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -21,9 +21,18 @@ config :edge_builder, EdgeBuilder.Endpoint,
   pubsub: [name: EdgeBuilder.PubSub, adapter: Phoenix.PubSub.PG2]
 
 # Configures Elixir's Logger
-config :logger, :console,
+config :logger,
   format: "$time $metadata[$level] $message\n",
-  metadata: [:request_id, :b_cookie, :s_cookie]
+  metadata: [:request_id, :b_cookie, :s_cookie],
+  backends: [:console, Sentry.LoggerBackend]
+
+config :sentry,
+  dsn: System.get_env("SENTRY_DSN"),
+  environment_name: Mix.env(),
+  included_environments: [:prod],
+  enable_source_code_context: true,
+  root_source_code_path: File.cwd!(),
+  json_library: Poison
 
 config :edge_builder, EdgeBuilder.Repo,
   adapter: Ecto.Adapters.Postgres,

--- a/lib/edge_builder/endpoint.ex
+++ b/lib/edge_builder/endpoint.ex
@@ -1,5 +1,6 @@
 defmodule EdgeBuilder.Endpoint do
   use Phoenix.Endpoint, otp_app: :edge_builder
+  use Sentry.Phoenix.Endpoint
 
   plug Plug.Static, at: "/", from: :edge_builder, only: ~w(css images js fonts
       favicon-16x16.png

--- a/mix.exs
+++ b/mix.exs
@@ -46,6 +46,7 @@ defmodule EdgeBuilder.Mixfile do
       {:bcrypt_elixir, "~> 2.0"},
       {:httpoison, "~> 1.6"},
       {:poison, "~> 3.1"},
+      {:sentry, "~> 7.0"},
       {:inflex, "~> 2.0"},
       {:mock, "~> 0.3.4", only: :test},
       {:excoveralls, "~> 0.12.1", only: :test},

--- a/mix.lock
+++ b/mix.lock
@@ -38,6 +38,7 @@
   "ranch": {:hex, :ranch, "1.7.1", "6b1fab51b49196860b733a49c07604465a47bdb78aa10c1c16a3d199f7f8c881", [:rebar3], [], "hexpm"},
   "scrivener": {:hex, :scrivener, "2.7.0", "fa94cdea21fad0649921d8066b1833d18d296217bfdf4a5389a2f45ee857b773", [:mix], [], "hexpm"},
   "scrivener_ecto": {:hex, :scrivener_ecto, "2.2.0", "53d5f1ba28f35f17891cf526ee102f8f225b7024d1cdaf8984875467158c9c5e", [:mix], [{:ecto, "~> 3.0", [hex: :ecto, repo: "hexpm", optional: false]}, {:scrivener, "~> 2.4", [hex: :scrivener, repo: "hexpm", optional: false]}], "hexpm"},
+  "sentry": {:hex, :sentry, "7.2.1", "ea6a5d26c4afef97bf21e09612ebe8d97b525b7822429092926377cd82c08f9e", [:mix], [{:hackney, "~> 1.8 or 1.6.5", [hex: :hackney, repo: "hexpm", optional: false]}, {:jason, "~> 1.1", [hex: :jason, repo: "hexpm", optional: true]}, {:phoenix, "~> 1.3", [hex: :phoenix, repo: "hexpm", optional: true]}, {:plug, "~> 1.6", [hex: :plug, repo: "hexpm", optional: true]}, {:plug_cowboy, "~> 1.0 or ~> 2.0", [hex: :plug_cowboy, repo: "hexpm", optional: true]}], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.5", "6eaf7ad16cb568bb01753dbbd7a95ff8b91c7979482b95f38443fe2c8852a79b", [:make, :mix, :rebar3], [], "hexpm"},
   "telemetry": {:hex, :telemetry, "0.4.1", "ae2718484892448a24470e6aa341bc847c3277bfb8d4e9289f7474d752c09c7f", [:rebar3], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},

--- a/web/router.ex
+++ b/web/router.ex
@@ -1,5 +1,7 @@
 defmodule EdgeBuilder.Router do
   use Phoenix.Router
+  use Plug.ErrorHandler
+  use Sentry.Plug
 
   pipeline :browser do
     plug :accepts, ~w(html)
@@ -19,7 +21,8 @@ defmodule EdgeBuilder.Router do
   end
 
   scope "/", EdgeBuilder do
-    pipe_through :browser # Use the default browser stack
+    # Use the default browser stack
+    pipe_through :browser
 
     get "/", PageController, :index
     get "/about", PageController, :about
@@ -28,11 +31,11 @@ defmodule EdgeBuilder.Router do
     resources "/u", ProfileController, only: [:show]
     resources "/v", VehicleController
     get "/my-creations", ProfileController, :my_creations
-    get  "/welcome", SignupController, :welcome
-    get  "/forgot-password", PasswordResetController, :request
-    post  "/forgot-password", PasswordResetController, :submit_request
-    get  "/password-reset", PasswordResetController, :reset
-    post  "/password-reset", PasswordResetController, :submit_reset
+    get "/welcome", SignupController, :welcome
+    get "/forgot-password", PasswordResetController, :request
+    post "/forgot-password", PasswordResetController, :submit_request
+    get "/password-reset", PasswordResetController, :reset
+    post "/password-reset", PasswordResetController, :submit_reset
     post "/login", SignupController, :login
     post "/logout", SignupController, :logout
     post "/signup", SignupController, :signup


### PR DESCRIPTION
Will need to set `SENTRY_DSN` environment variable on the server. It's even okay if we don't though on DO before the next deploy as it'll just ignore exceptions. 

```
[warn] Failed to send Sentry event.Cannot send Sentry event because of invalid DSN
```

I'll make sure to have this on Heroku though.

Closes #147.