### PR TITLE
Add error handling around empty password resets

### DIFF
--- a/test/controllers/password_reset_controller_test.exs
+++ b/test/controllers/password_reset_controller_test.exs
@@ -129,6 +129,42 @@ defmodule EdgeBuilder.Controllers.PasswordResetControllerTest do
       assert Plug.Conn.get_session(conn, :current_user_username) == user.username
     end
 
+    it "doesn't allow an empty password" do
+      user = UserFactory.create_user!() |> UserFactory.add_password_reset_token()
+
+      conn =
+        build_conn()
+        |> post("/password-reset", %{
+          "password_reset" => %{
+            "password" => "",
+            "password_confirmation" => "non-empty-confirmation",
+            "token" => user.password_reset_token
+          }
+        })
+
+      assert FlokiExt.element(conn, ".alert-danger")
+             |> FlokiExt.text()
+             |> String.contains?("Password can't be blank")
+    end
+
+    it "doesn't allow an empty password confirmation" do
+      user = UserFactory.create_user!() |> UserFactory.add_password_reset_token()
+
+      conn =
+        build_conn()
+        |> post("/password-reset", %{
+          "password_reset" => %{
+            "password" => "non-empty-password",
+            "password_confirmation" => "",
+            "token" => user.password_reset_token
+          }
+        })
+
+      assert FlokiExt.element(conn, ".alert-danger")
+             |> FlokiExt.text()
+             |> String.contains?("Password confirmation can't be blank")
+    end
+
     it "redirects to the welcome page with a notice about resetting the password" do
       user = UserFactory.create_user!() |> UserFactory.add_password_reset_token()
 

--- a/web/controllers/password_reset_controller.ex
+++ b/web/controllers/password_reset_controller.ex
@@ -28,7 +28,7 @@ defmodule EdgeBuilder.PasswordResetController do
     case find_user_by_token(params["token"]) do
       nil -> render_404(conn)
       user ->
-        user = User.changeset(user, :password_reset, Map.put(params, "password_reset_token", nil))
+        user = User.changeset(user, :confirm_password_reset, Map.put(params, "password_reset_token", nil))
         if user.valid? do
           user = Repo.update!(user)
           conn

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -37,6 +37,14 @@ defmodule EdgeBuilder.Models.User do
     |> shared_validations
   end
 
+  def changeset(user, :confirm_password_reset, params) do
+    user
+    |> cast(params, ~w(password password_confirmation password_reset_token)a)
+    |> validate_required([:password])
+    |> validate_required([:password_confirmation], name: "Password Confirmation")
+    |> shared_validations
+  end
+
   def changeset(user, :contributions, params) do
     user
     |> cast(params, ~w(bug_reported_at pull_requested_at)a)

--- a/web/templates/password_reset/reset.html.eex
+++ b/web/templates/password_reset/reset.html.eex
@@ -8,11 +8,11 @@
   <%= form_tag(Routes.password_reset_path(@conn, :submit_reset), role: "form", method: "POST", class: "form well") %>
     <div class="form-group">
       <label for="password_reset[password]" class="control-label">Password</label>
-      <input type="password" class="form-control" name="password_reset[password]" />
+      <input type="password" class="form-control" required name="password_reset[password]" />
     </div>
     <div class="form-group">
       <label for="password_reset[password_confirmation]" class="control-label">Password Confirmation</label>
-      <input type="password" class="form-control" name="password_reset[password_confirmation]" />
+      <input type="password" class="form-control" required name="password_reset[password_confirmation]" />
     </div>
     <input type="hidden" name="password_reset[token]" value="<%= @token %>" />
     <input class="btn btn-primary btn-block" type="submit" value="Change my password">

--- a/web/templates/shared/_errors.html.eex
+++ b/web/templates/shared/_errors.html.eex
@@ -2,7 +2,7 @@
   <div class="alert alert-danger">
     <ul>
       <%= for {field, {error, _}} <- @errors do %>
-        <li><strong><%= field |> Atom.to_string |> String.capitalize %></strong> <%= error %></li>
+        <li><strong><%= field |> Atom.to_string |> String.capitalize |> String.replace("_", " ") %></strong> <%= error %></li>
       <% end %>
     </ul>
   </div>


### PR DESCRIPTION
Related issue: #186

Howdy! This is that guy from reddit and I found I had some free time so I figured I'd tackle this really quick!

This adds a few things to resolve the issue at hand:

1. Submission of the form goes through a stricter changeset which requires a `password` and `password_confirmation` field
1. Because it uses a changeset, we get free error messages through the template :)
1. `required` attributes for the `<input>` elements have been added, letting browsers also prevent empty submissions on the client without any extra js!

Please let me know if there's anything you'd like to change, even as small as a code style nitpick!