### PR TITLE
Add classes to target "Other Notes" for monospace

### DIFF
--- a/web/templates/character/show.html.eex
+++ b/web/templates/character/show.html.eex
@@ -322,7 +322,7 @@
 <div class="row">
   <h4>Other Notes</h4>
   <div class="col-md-12">
-    <div class="long-text"><%= render_text(@character, :other_notes) %></div>
+    <div class="long-text other-notes monospace"><%= render_text(@character, :other_notes) %></div>
   </div>
 </div>
 


### PR DESCRIPTION
Classes being added for eventual CSS improvements for monospace tables in the Other Notes section, which is being used as a catch-all for homebrew materials.