### PR TITLE
Improve Print Layouts, Add Monospace Class

### DIFF
--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -295,3 +295,12 @@ body.v .alert {
 .patron-senate {
   font-size: 3.5rem;
 }
+@media print {
+.save-panel {
+  display: none;
+  }
+#dieAbility, #dieProficiency {
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+}

--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -295,6 +295,11 @@ body.v .alert {
 .patron-senate {
   font-size: 3.5rem;
 }
+
+.monospace {
+  font-family: Consolas, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", Monaco, "Courier New", Courier, monospace;
+}
+
 @media print {
 .save-panel {
   display: none;


### PR DESCRIPTION
+ Larger #dieAbility, #dieProficiency glyphs (fixed dimensions means later higher quality PNG or SVGs can be used), dice are irregularly sized in print preview.
+ Hides the .save-well when printing (print preview on Chrome on MacOS shows well).
@media print used exclusively for print layouts, formatting.

+ Adds safe monospace fontstack and .monospace class.